### PR TITLE
Implement wrappers for unbind and unsubscribe methods on amqp

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -210,6 +210,7 @@ Bus.prototype.direct = function(addr, msg, options, cb) {
   if (cb) { return process.nextTick(cb); }
 }
 
+
 /**
  * Subscribe to messages of `topic` broadcast on the bus.
  *
@@ -290,13 +291,16 @@ Bus.prototype._subscribe = function(options, cb) {
   q.subscribe(options, function(message, headers, deliveryInfo) {
     var m = new Message(message, headers, deliveryInfo);
     m.bus = self;
-    
     self.emit('message', m);
   }).addCallback(function(ok) {
     // This callback is invoked when the subscription was successful, and is
     // equivalent to the registering a listener for the queue's `basicConsumeOk`
     // event.
     q.removeListener('error', onError);
+    
+    // Store the consumerTag so that this queue may also be unsubscribed from.
+    self._consumerTag = ok.consumerTag;
+
     return cb();
   }).addErrback(function(err) {
     // NOTE: Promise errbacks are not properly invoked by the underlying `amqp`
@@ -315,6 +319,70 @@ Bus.prototype._subscribe = function(options, cb) {
   q.once('error', onError);
 }
 
+/**
+ * Desubscribe to messages of `topic` broadcast on the bus.
+ *
+ *
+ * Examples:
+ *
+ *     bus.unsubscribe('events/on');
+ *
+ * @param {String} queue
+ * @param {Object} options
+ * @param {Function} cb
+ * @api public
+ */
+Bus.prototype.unsubscribe = function(topic, options, cb) {
+  if (typeof options == 'function') {
+    cb = options;
+    options = undefined;
+  }
+
+  options = options || {};
+  
+  if (!this._queue) { return cb(new NoQueueError('Bus not in listening mode')); }
+  
+  // AMQP uses period ('.') separators rather than slash ('/')
+  topic = topic.replace(/\//g, '.');
+  
+  var q = this._queue
+    , exchange = this._exchange.name;
+  
+  var onError = function(err) {
+    return cb(err);
+  };
+  
+  debug('unbind %s %s %s', q.name, exchange, topic);
+  q.unbind(exchange, topic)
+    .on('queueUnbindOk', function(){
+      return cb();
+    });
+}
+
+/**
+ * Unsubscribe to an internal queue.
+ *
+ * @param {Object} options
+ * @param {Function} cb
+ * @api private
+ */
+Bus.prototype._unsubscribe = function(options, cb) {
+  if (typeof options == 'function') {
+    cb = options;
+    options = undefined;
+  }
+  options = options || {};
+  
+  var self = this
+    , q = this._queue;
+    
+  var onError = function(err) {
+    return cb(err);
+  };
+    
+  debug('unsubscribe %s', q.name);
+  q.unsubscribe(self._consumerTag);
+}
 
 /**
  * Expose `Bus`.


### PR DESCRIPTION
This pull request adds two additional methods to Bus, and adds one additional value to Bus instances. The additional value is a _consumerTag. The two methods are _unsubscribe() and unsubscribe(). unsubscribe() calls the amqp unbind method on a given topic and exchange. It is the opposite of the already existing subscribe() method on Bus. _unsubscribe() calls the amqp unsubscribe method from the internal queue of the Bus. It is the opposite of the already existing _subscribe() method. The additional value of _consumerTag is now set by _subscribe() in the q.subscribe() callback. This is to maintain the reference necessary to use the unsubscribe method from amqp.
